### PR TITLE
Fix Current Issues 2017-02-08

### DIFF
--- a/study.md
+++ b/study.md
@@ -72,7 +72,7 @@ entity)?
 ## Rails Console
 
 For the subsequent questions, assume that we are in the Rails console (by
-entering `bin/rails dbconsole` in the terminal) and that the model names follow
+entering `bin/rails console` in the terminal) and that the model names follow
 Rails's naming conventions.  e.g., The name of the model for a "people"
 collection would be "Person".
 

--- a/study.md
+++ b/study.md
@@ -72,9 +72,9 @@ entity)?
 ## Rails Console
 
 For the subsequent questions, assume that we are in the Rails console (by
-entering `rails console` in the terminal and that the model names follow Rails
-naming conventions.  e.g., The name of the model for a "people" collection would
-be "Person".
+entering `bin/rails dbconsole` in the terminal and that the model names follow
+Rails's naming conventions.  e.g., The name of the model for a "people"
+collection would be "Person".
 
 ## Create
 

--- a/study.md
+++ b/study.md
@@ -72,7 +72,7 @@ entity)?
 ## Rails Console
 
 For the subsequent questions, assume that we are in the Rails console (by
-entering `bin/rails dbconsole` in the terminal and that the model names follow
+entering `bin/rails dbconsole` in the terminal) and that the model names follow
 Rails's naming conventions.  e.g., The name of the model for a "people"
 collection would be "Person".
 


### PR DESCRIPTION
- Change "rails console" to "bin/rails console". Close #98.
- Change "Rails" to "Rails's".
- Add a missing parenthesis after "terminal".  Fix #116.